### PR TITLE
Commands to add/remove a client's scopes

### DIFF
--- a/cmd/clients_scopes.go
+++ b/cmd/clients_scopes.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// policyActionsAddCmd represents the add command
+var clientsScopesCmd = &cobra.Command{
+	Use:   "scopes",
+	Short: "Manage a client's scopes",
+}
+
+func init() {
+	clientsCmd.AddCommand(clientsScopesCmd)
+}

--- a/cmd/clients_scopes_add.go
+++ b/cmd/clients_scopes_add.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// policyActionsAddCmd represents the add command
+var clientsScopesAddCmd = &cobra.Command{
+	Use:   "add <client> <scope> [<scope>...]",
+	Short: "Add scopes to the client",
+	Long: `You can use regular expressions in your matches. Encapsulate them in < >.
+
+Example:
+  hydra clients scopes add my-client newscope`,
+	Run: cmdHandler.Clients.AddScopeToClient,
+}
+
+func init() {
+	clientsScopesCmd.AddCommand(clientsScopesAddCmd)
+}

--- a/cmd/clients_scopes_remove.go
+++ b/cmd/clients_scopes_remove.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// policyActionsAddCmd represents the add command
+var clientsScopesRemoveCmd = &cobra.Command{
+	Use:   "remove <client> <scope> [<scope>...]",
+	Short: "Remove scopes from the client",
+	Run:   cmdHandler.Clients.RemoveScopeFromClient,
+}
+
+func init() {
+	clientsScopesCmd.AddCommand(clientsScopesRemoveCmd)
+}


### PR DESCRIPTION
Add commands to add/remove the scopes of a client.

Tested it with sand-dev.

- [x] @johnny-lai  