### PR TITLE
Lazy load the statsd client due to telegraf taking time to start

### DIFF
--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -101,7 +101,7 @@ func newOAuth2Provider(c *config.Config, km jwk.Manager) fosite.OAuth2Provider {
 	)
 }
 
-func newOAuth2Handler(c *config.Config, router *httprouter.Router, km jwk.Manager, o fosite.OAuth2Provider, statsd *statsd.Client) *oauth2.Handler {
+func newOAuth2Handler(c *config.Config, router *httprouter.Router, km jwk.Manager, o fosite.OAuth2Provider, statsdFactory func() *statsd.Client) *oauth2.Handler {
 	if c.ConsentURL == "" {
 		proto := "https"
 		if c.ForceHTTP {
@@ -132,7 +132,7 @@ func newOAuth2Handler(c *config.Config, router *httprouter.Router, km jwk.Manage
 		CookieStore:         sessions.NewCookieStore(c.GetCookieSecret()),
 		Issuer:              c.Issuer,
 		L:                   c.GetLogger(),
-		Statsd:              statsd,
+		StatsdFactory:       statsdFactory,
 	}
 
 	handler.SetRoutes(router)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Starting telegraf agent for statsd..."
 telegraf &
-sleep 3
+
 # NOTE: Never use TEST_SAND_MIGRATE_DB in production
 if [ "$TEST_SAND_MIGRATE_DB" == 'true' ]; then
     echo "migrating db..."

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -50,8 +50,9 @@ type Handler struct {
 
 	L logrus.FieldLogger
 
-	Issuer string
-	Statsd *statsd.Client
+	Issuer        string
+	StatsdFactory func() *statsd.Client
+	Statsd        *statsd.Client
 }
 
 // swagger:model WellKnown
@@ -260,6 +261,9 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var session = NewSession("")
 	var ctx = fosite.NewContext()
+	if h.Statsd == nil {
+		h.Statsd = h.StatsdFactory()
+	}
 
 	// NOTE: if we can't get the accessRequest object below, then we don't know what the client_id is
 	sandClientId := ""


### PR DESCRIPTION
SRE updated Sand's AMI for security vulnerabilities, and after that telegraf startup seemed to take more time.

So changed the statsd client to be lazy loading.

- [x] @abdollar 