### PR TITLE
CD-218194: Use base docker image

### DIFF
--- a/Dockerfile-sand
+++ b/Dockerfile-sand
@@ -1,8 +1,23 @@
-#- sand image --------------------------------------------------------------
-FROM 899991151204.dkr.ecr.us-east-1.amazonaws.com/alpine:3.10-fips
-RUN apk add --update ca-certificates
-ADD tmp/dist/sand /bin/sand
-ADD entrypoint.sh /
+FROM 899991151204.dkr.ecr.us-east-1.amazonaws.com/golang:alpine as sand-builder
 
-ENTRYPOINT ["/entrypoint.sh"]
+RUN sudo apk add git \
+	gcc \
+	libc-dev
+
+ENV BUILD_ROOT=/go/src/github.com/ory/hydra/tmp/dist
+
+RUN mkdir -p /go/src/github.com/ory/hydra
+
+COPY --chown=app:app . /go/src/github.com/ory/hydra
+
+RUN cd /go/src/github.com/ory/hydra && \
+	make distbuild 
+
+RUN sudo cp /go/src/github.com/ory/hydra/tmp/dist/sand /usr/bin/sand
+#- sand image --------------------------------------------------------------
+FROM 899991151204.dkr.ecr.us-east-1.amazonaws.com/alpine:latest
+COPY --from=sand-builder --chown=app:app /usr/bin/sand /usr/bin/sand
+ADD entrypoint.sh /usr/bin/
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 EXPOSE 4444

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILDER_IMAGE = 899991151204.dkr.ecr.us-east-1.amazonaws.com/goboring:1.13-alpine3.10
+BUILDER_IMAGE = 899991151204.dkr.ecr.us-east-1.amazonaws.com/golang:alpine
 
 SRCROOT ?= $(realpath .)
 BUILD_ROOT ?= $(SRCROOT)
@@ -30,23 +30,10 @@ build-linux:
 	&& echo "build successful. now checking goboring symbols exists..." && go tool nm $(BUILD_ROOT)/sand-linux | grep _Cfunc__goboringcrypto_ > /dev/null
 	tar cvzf $(BUILD_ROOT)/sand-$(VERSION)-linux.tgz $(BUILD_ROOT)/sand-linux
 
-dist:
-	docker pull $(BUILDER_IMAGE)
-	docker run --rm \
-	           -v $(SRCROOT):$(SRCROOT_D) \
-	           -w $(SRCROOT_D) \
-	           -e BUILD_ROOT=$(BUILD_ROOT_D) \
-	           -e UID=`id -u` \
-	           -e GID=`id -g` \
-	           $(BUILDER_IMAGE) \
-	           make distbuild
-
 distbuild: clean build build-osx build-linux
-	-chown -R $(UID):$(GID) $(SRCROOT)
 
 clean:
 	if [ -d $(BUILD_ROOT_D) ]; then rm -rf $(BUILD_ROOT_D); fi
-	-chown -R $(UID):$(GID) $(SRCROOT)
 	if [ -d $(SRCROOT)/vendor ]; then rm -rf $(SRCROOT)/vendor; fi
 
 .PHONY: bin default build build-osx build-linux dist distbuild clean

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,12 +5,12 @@
 # NOTE: Never use TEST_SAND_MIGRATE_DB in production
 if [ "$TEST_SAND_MIGRATE_DB" == 'true' ]; then
     echo "migrating db..."
-    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand migrate" /bin/sand migrate sql $DATABASE_URL
+    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand migrate" /usr/bin/sand migrate sql $DATABASE_URL
 fi
 echo "Starting sand..."
 # NOTE: Never use TEST_SAND_DANGEROUS_FORCE_HTTP in production
 if [ "$TEST_SAND_DANGEROUS_FORCE_HTTP" == 'true' ]; then
-    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand server" /bin/sand host --dangerous-force-http
+    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand server" /usr/bin/sand host --dangerous-force-http
 else
-    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand server" /bin/sand host
+    LD_PRELOAD=/usr/lib/libfipsify.so PROCESS_NAME="sand server" /usr/bin/sand host
 fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/hydra
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78


### PR DESCRIPTION
### Jira ticket:

Main ticket: https://coupadev.atlassian.net/browse/CD-218194

### Summary of Change:
Using base docker image.
There were some packages that were not present in base docker image, so added builder docker that installs the missing packages and builds the sand binary.
Base docker image, uses go version 1.14, so updated it in go.mod.

### Reviewer:
- [x] @johnwu96822 
- [x] @abdollar 

### Testing:
Created a separate temp jenkins job to test this - https://jenkins-dev.coupadev.com/job/SERVICES/job/sand/job/sand-test/6/console