### PR TITLE
Fix the config schema for missing the db.ssl.cert properties

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -399,6 +399,24 @@
       "type": "string",
       "description": "Sets the data source name. This configures the backend where ORY Hydra persists data. If dsn is \"memory\", data will be written to memory and is lost when you restart this instance. ORY Hydra supports popular SQL databases. For more detailed configuration information go to: https://www.ory.sh/docs/hydra/dependencies-environment#sql"
     },
+    "db": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configures db settings.",
+      "properties": {
+        "ssl": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Configures db ssl options.",
+          "properties": {
+            "cert": {
+              "type": "string",
+              "description": "The db ssl certificate string."
+            }
+          }
+        }
+      }
+    },
     "webfinger": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
Was missing the config schema for the db ssl cert. Hence the app would complain and fail.

- [x] @abdulchaudhrycoupa 