### PR TITLE
Remove health endpoint access log; remove excessive deprecation warni…

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -200,7 +200,7 @@ func setup(d driver.Driver, cmd *cobra.Command) (admin *x.RouterAdmin, public *x
 		NewMiddlewareFromLogger(d.Registry().Logger(),
 			fmt.Sprintf("hydra/admin: %s", d.Configuration().IssuerURL().String()))
 	if d.Configuration().AdminDisableHealthAccessLog() {
-		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath, "/health")
 	}
 
 	adminmw.Use(adminLogger)
@@ -212,7 +212,7 @@ func setup(d driver.Driver, cmd *cobra.Command) (admin *x.RouterAdmin, public *x
 		fmt.Sprintf("hydra/public: %s", d.Configuration().IssuerURL().String()),
 	)
 	if d.Configuration().PublicDisableHealthAccessLog() {
-		publicLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+		publicLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath, "/health")
 	}
 
 	publicmw.Use(publicLogger)

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -431,8 +431,13 @@ func (v *ViperProvider) PublicURL() *url.URL {
 	return urlRoot(urlx.ParseOrFatal(v.l, viperx.GetString(v.l, ViperKeyPublicURL, v.publicFallbackURL("/"))))
 }
 
+var issuerURL *url.URL
+
 func (v *ViperProvider) IssuerURL() *url.URL {
-	return urlRoot(urlx.ParseOrFatal(v.l, strings.TrimRight(viperx.GetString(v.l, ViperKeyIssuerURL, v.fallbackURL("/", v.publicHost(), v.publicPort()), "OAUTH2_ISSUER_URL", "ISSUER", "ISSUER_URL"), "/")+"/"))
+	if issuerURL == nil {
+		issuerURL = urlRoot(urlx.ParseOrFatal(v.l, strings.TrimRight(viperx.GetString(v.l, ViperKeyIssuerURL, v.fallbackURL("/", v.publicHost(), v.publicPort()), "OAUTH2_ISSUER_URL", "ISSUER", "ISSUER_URL"), "/")+"/"))
+	}
+	return issuerURL
 }
 
 func (v *ViperProvider) OAuth2AuthURL() string {


### PR DESCRIPTION
…ngs from using the env variable for issuer

We still use the env variable for issuer, despite hydra moving to the config file (we are not doing that yet). So we read the issuer only once and cache it to a variable. This way it doesn't print out the deprecation warning every time it's read. Can revert the commit if one day we start using the config file.

- [x] @abdulchaudhrycoupa 