### PR TITLE
Fix client id empty when getting client from old Sand

### DIFF
--- a/client/manager_http.go
+++ b/client/manager_http.go
@@ -28,7 +28,11 @@ func (m *HTTPManager) GetConcreteClient(id string) (*Client, error) {
 	if err := r.Get(&c); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	c.ID = c.ClientID
+	if c.ID == "" {
+		c.ID = c.ClientID
+	} else if c.ClientID == "" {
+		c.ClientID = c.ID
+	}
 	return &c, nil
 }
 


### PR DESCRIPTION
The get client command running against the old Sand was not displaying either `id` or `client_id` in the response.

So tweak the CLI to set them from either source. The old version of Sand's response is `id` and the new Sand's response is `client_id`.

- [x] @abdulchaudhrycoupa 