### PR TITLE
Revert to the old behavior for ext field, which is nil

### DIFF
--- a/warden/warden_local.go
+++ b/warden/warden_local.go
@@ -179,7 +179,9 @@ func (w *LocalWarden) newContext(auth fosite.AccessRequester) *firewall.Context 
 		Audience:      auth.GetClient().GetID(),
 		IssuedAt:      auth.GetRequestedAt(),
 		ExpiresAt:     exp,
-		Extra:         session.Extra,
+		//Set Extra to nil until sand-java clients are fixed
+		//We don't use this btw.
+		Extra: nil, // session.Extra,
 	}
 
 	return c


### PR DESCRIPTION
The `ext` field in the token verification response used to be nil. The new version of Hydra has it defaulted to empty map `{}`. This is breaking sand-java which wrongly assume the field to be a string.

So restore the old behavior. And since we don't use the field, just set it to nil.

Tested locally and worked with sand-java.

