### PR TITLE
Patch the error message returned when client create failed, to satisf…

### DIFF
--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -156,7 +156,15 @@ func (m *SQLManager) CreateClient(ctx context.Context, c *Client) error {
 		),
 		setDefaults(c),
 	); err != nil {
-		return sqlcon.HandleError(err)
+		handlerErr := sqlcon.HandleError(err)
+		cause := errors.Cause(handlerErr)
+		if cause == sqlcon.ErrUniqueViolation {
+			// Make a copy of ErrUniqueViolation
+			uniqueViolation := *sqlcon.ErrUniqueViolation
+			uniqueViolation.ErrorField += "; Error 1062: Duplicate entry"
+			return errors.Wrap(&uniqueViolation, err.Error())
+		}
+		return handlerErr
 	}
 
 	return nil


### PR DESCRIPTION
…y existing ops code

There are existing ops code that checks for `Error 1062: Duplicate entry` when client create fails. New version of Hydra changed the error message.

Patch hydra to add `Error 1062: Duplicate entry` to the error message so that ops code won't fail.

Tested locally. Original:
```
{"error":"Unable to insert or update resource because a resource with that value exists already",
"error_verbose":"",
"error_description":"",
"status_code":409}
```
Now it returns:
```
{"error":"Unable to insert or update resource because a resource with that value exists already; Error 1062: Duplicate entry",
"error_verbose":"",
"error_description":"",
"status_code":409}
```

- [ ] @abdulchaudhrycoupa 