### PR TITLE
Some dependencies all the sudden requires py3-pip. So added it

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE
 
 FROM ${BUILDER_IMAGE}
 
-RUN sudo apk add git bash build-base && \
+RUN sudo apk add py3-setuptools git bash build-base && \
     go get -u github.com/gobuffalo/packr/v2/packr2
 
 COPY --chown=app . /go/src/github.com/ory/hydra

--- a/Dockerfile-builder-nonfips
+++ b/Dockerfile-builder-nonfips
@@ -1,6 +1,6 @@
 FROM golang:1.15-alpine
 
-RUN apk add git bash build-base && \
+RUN apk add py3-setuptools git bash build-base && \
     go get -u github.com/gobuffalo/packr/v2/packr2
 
 COPY . /go/src/github.com/ory/hydra


### PR DESCRIPTION
Some dependent package is requiring py3-pip:
```
Step 3/9 : RUN sudo apk add git bash build-base &&     go get -u github.com/gobuffalo/packr/v2/packr2
 ---> Running in af56bfce73eb
sudo: setrlimit(RLIMIT_CORE): Operation not permitted
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  py3-pip (virtual):
    provided by: python3
    required by: world[py3-pip]
The command '/bin/sh -c sudo apk add git bash build-base &&     go get -u github.com/gobuffalo/packr/v2/packr2' returned a non-zero code: 1
Makefile:186: recipe for target 'docker.build' failed
```
So install the package with apk.

